### PR TITLE
fully qualify std::mem

### DIFF
--- a/src/varianteq.rs
+++ b/src/varianteq.rs
@@ -9,7 +9,7 @@ pub fn derive(item: DeriveInput) -> Result<Tokens, Diagnostic> {
     Ok(quote! {
         impl PartialEq for #ident {
             fn eq(&self, other: &#ident) -> bool {
-                std::mem::discriminant(self) == std::mem::discriminant(other)
+                ::std::mem::discriminant(self) == ::std::mem::discriminant(other)
             }
         }
         impl Eq for #ident {}


### PR DESCRIPTION
 `std::mem` is a relative path so you either have to be in the root module or have `use std` somewhere in the module deriving `VariantEq`
specifying the path from the root removes that requirement